### PR TITLE
Decay

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="footbot",
-    version="0.2.1",
+    version="0.2.2",
     url='https://github.com/thomas-woodruff/footbot',
     author='thomas-woodruff',
     license='All rights reserved.',

--- a/tests/integration/research/utils/test_int_simulator.py
+++ b/tests/integration/research/utils/test_int_simulator.py
@@ -97,6 +97,7 @@ def test_make_transfers_from_scratch(elements_df, predictions_df):
     existing_squad, bank, transfers = make_transfers(
         event=test_event,
         events_to_look_ahead=0,
+        weight=1.0,
         existing_squad=[],
         total_budget=1000,
         first_team_factor=0.9,
@@ -154,6 +155,7 @@ def test_make_transfers_from_existing(elements_df, predictions_df):
     existing_squad, bank, transfers = make_transfers(
         event=test_event,
         events_to_look_ahead=0,
+        weight=1.0,
         existing_squad=[
             213,
             78,
@@ -288,6 +290,7 @@ def test_simulate_event(all_elements_df, all_predictions_df, all_results_df, cli
         bank=None,
         transfers_made=None,
         events_to_look_ahead=0,
+        weight=1.0,
         events_to_look_ahead_from_scratch=0,
         first_team_factor=0.9,
         bench_factor=0.1,
@@ -314,6 +317,7 @@ def test_simulate_events(all_elements_df, all_predictions_df, all_results_df, cl
         all_predictions_df=all_predictions_df,
         all_results_df=all_results_df,
         events_to_look_ahead=0,
+        weight=1.0,
         events_to_look_ahead_from_scratch=0,
         first_team_factor=0.9,
         bench_factor=0.1,
@@ -343,6 +347,7 @@ def test_simulate_events_wildcard(
         all_predictions_df=all_predictions_df,
         all_results_df=all_results_df,
         events_to_look_ahead=0,
+        weight=1.0,
         events_to_look_ahead_from_scratch=0,
         first_team_factor=0.9,
         bench_factor=0.1,
@@ -381,6 +386,7 @@ def test_simulate_events_free_hit(
         all_predictions_df=all_predictions_df,
         all_results_df=all_results_df,
         events_to_look_ahead=0,
+        weight=1.0,
         events_to_look_ahead_from_scratch=0,
         first_team_factor=0.9,
         bench_factor=0.1,

--- a/tests/unit/research/utils/test_simulator.py
+++ b/tests/unit/research/utils/test_simulator.py
@@ -24,13 +24,18 @@ def test_aggregate_predictions():
         ]
     )
 
-    df = aggregate_predictions(predictions_df, 1, 3)
+    df = aggregate_predictions(
+        predictions_df,
+        start_event=1,
+        end_event=3,
+        weight=0.5
+    )
 
     expected_df = pd.DataFrame(
         [
-            {"element_all": 1, "avg_predicted_total_points": 2.0},
-            {"element_all": 2, "avg_predicted_total_points": 1.0},
-            {"element_all": 3, "avg_predicted_total_points": 3.0},
+            {"element_all": 1, "predicted_total_points": 2.75},
+            {"element_all": 2, "predicted_total_points": 2.0},
+            {"element_all": 3, "predicted_total_points": 4.25},
         ]
     )
 
@@ -49,7 +54,13 @@ def test_get_team_selector_input():
         ]
     )
 
-    players = get_team_selector_input(predictions_df, elements_df, 1, 1)
+    players = get_team_selector_input(
+        predictions_df,
+        elements_df,
+        start_event=1,
+        end_event=1,
+        weight=1.0
+    )
 
     expected_players = [
         {
@@ -57,14 +68,14 @@ def test_get_team_selector_input():
             "element_type": 1,
             "team": 1,
             "value": 10.0,
-            "avg_predicted_total_points": 1.0,
+            "predicted_total_points": 1.0,
         },
         {
             "element": 2,
             "element_type": 4,
             "team": 3,
             "value": 7.5,
-            "avg_predicted_total_points": 0.0,
+            "predicted_total_points": 0.0,
         },
     ]
 
@@ -752,6 +763,7 @@ def test_make_transfers_from_scratch(elements_df, predictions_df):
     existing_squad, bank, transfers = make_transfers(
         event=1,
         events_to_look_ahead=1,
+        weight=1.0,
         existing_squad=[],
         total_budget=600,
         first_team_factor=0.9,
@@ -777,6 +789,7 @@ def test_make_transfers_from_existing(elements_df, predictions_df):
     existing_squad, bank, transfers = make_transfers(
         event=1,
         events_to_look_ahead=1,
+        weight=1.0,
         existing_squad=[1, 7, 8, 9, 12, 13, 14, 15, 17, 18, 19, 2, 5, 6, 11],
         total_budget=600,
         first_team_factor=0.9,

--- a/tests/unit/research/utils/test_simulator.py
+++ b/tests/unit/research/utils/test_simulator.py
@@ -6,6 +6,7 @@ from footbot.research.utils.simulator import get_points_calculator_input
 from footbot.research.utils.simulator import get_team_selector_input
 from footbot.research.utils.simulator import make_transfers
 from footbot.research.utils.simulator import set_event_state
+from footbot.research.utils.simulator import validate_all_predictions_df
 
 
 def test_aggregate_predictions():
@@ -24,12 +25,7 @@ def test_aggregate_predictions():
         ]
     )
 
-    df = aggregate_predictions(
-        predictions_df,
-        start_event=1,
-        end_event=3,
-        weight=0.5
-    )
+    df = aggregate_predictions(predictions_df, start_event=1, end_event=3, weight=0.5)
 
     expected_df = pd.DataFrame(
         [
@@ -55,11 +51,7 @@ def test_get_team_selector_input():
     )
 
     players = get_team_selector_input(
-        predictions_df,
-        elements_df,
-        start_event=1,
-        end_event=1,
-        weight=1.0
+        predictions_df, elements_df, start_event=1, end_event=1, weight=1.0
     )
 
     expected_players = [
@@ -808,3 +800,30 @@ def test_make_transfers_from_existing(elements_df, predictions_df):
         "transfers_in": {3},
         "transfers_out": {1},
     }
+
+
+def test_validate_all_predictions_df():
+
+    all_predictions_df = pd.DataFrame(
+        [
+            {
+                "prediction_event": 1,
+                "event": 1,
+                "element_all": 1,
+                "opponent_team": 1,
+                "predicted_total_points": 5.0,
+            },
+            {
+                "prediction_event": 1,
+                "event": 1,
+                "element_all": 1,
+                "opponent_team": 1,
+                "predicted_total_points": 6.0,
+            },
+        ]
+    )
+
+    with pytest.raises(Exception) as e:
+        validate_all_predictions_df(all_predictions_df)
+
+    assert "`all_predictions_df` contains duplicate entries" in str(e.value)


### PR DESCRIPTION
Rather than just average predicted points over the relevant future events, we take a weighted sum. The weights are given by an exponential decay:

`weight = lambda**{event - current event}`

where lambda can be chosen.

This takes into account that the benefit of transferring a player into the team is reflected by the sum of their future predicted points, rather than their average. It also us to discount future events. We might do this because we're not sure how long the player will stay in the team, for example.