### PR TITLE
21/22 data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ clean: clean-container clean-image
 
 .PHONY: clean-container
 clean-container:
-	docker rm -f $(NAME)
+	docker rm -f $(NAME) || true
 
 .PHONY: clean-image
 clean-image:
-	docker image rm $(NAME)_$(NAME)
+	docker image rm $(NAME)_$(NAME) || true
 
 .PHONY: format
 format: black isort lint

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,1 +1,10 @@
 cron:
+  - description: "Update element data on BigQuery"
+    url: /update_element_data
+    schedule: every day 06:00
+  - description: "Update element gameweek history and fixtures on BigQuery"
+    url: /update_element_history_fixtures
+    schedule: every day 06:05
+  - description: "Update predictions for upcoming gameweeks on BigQuery"
+    url: /update_predictions
+    schedule: every day 09:00

--- a/footbot/main.py
+++ b/footbot/main.py
@@ -42,24 +42,24 @@ def update_element_history_fixtures_worker(element, delete=False):
     if delete:
         logger.info(f"deleting element {element} gameweek history")
         utils.run_query(
-            f"DELETE FROM `footbot-001.fpl.element_gameweeks_2021` WHERE element = {element}",
+            f"DELETE FROM `footbot-001.fpl.element_gameweeks_2122` WHERE element = {element}",
             client,
         )
 
     logger.info(f"writing element {element} gameweek history")
-    utils.write_to_table("fpl", "element_gameweeks_2021", element_history_df, client)
+    utils.write_to_table("fpl", "element_gameweeks_2122", element_history_df, client)
     logger.info(f"done writing element {element} gameweek history")
 
     if delete:
         logger.info(f"deleting element {element} fixtures")
         utils.run_query(
-            f"DELETE FROM `footbot-001.fpl.element_future_fixtures_2021` WHERE element = {element}",
+            f"DELETE FROM `footbot-001.fpl.element_future_fixtures_2122` WHERE element = {element}",
             client,
         )
 
     logger.info(f"writing element {element} fixtures")
     utils.write_to_table(
-        "fpl", "element_future_fixtures_2021", element_fixtures_df, client
+        "fpl", "element_future_fixtures_2122", element_fixtures_df, client
     )
     logger.info(f"done writing element {element} fixtures")
 
@@ -78,7 +78,7 @@ def update_element_data_route():
     client = utils.set_up_bigquery()
 
     logger.info("writing element data")
-    utils.write_to_table("fpl", "element_data_2021", element_df, client)
+    utils.write_to_table("fpl", "element_data_2122", element_df, client)
     logger.info("done writing element data")
 
     return "Updated element data, baby"
@@ -100,12 +100,12 @@ def update_element_history_fixtures_route():
 
     logger.info("deleting element gameweek history")
     utils.run_query(
-        "DELETE FROM `footbot-001.fpl.element_gameweeks_2021` WHERE true",
+        "DELETE FROM `footbot-001.fpl.element_gameweeks_2122` WHERE true",
         big_query_client,
     )
     logger.info("deleting element fixtures")
     utils.run_query(
-        "DELETE FROM `footbot-001.fpl.element_future_fixtures_2021` WHERE true",
+        "DELETE FROM `footbot-001.fpl.element_future_fixtures_2122` WHERE true",
         big_query_client,
     )
 
@@ -152,7 +152,7 @@ def update_predictions_route():
     logger.info("writing predictions")
     utils.write_to_table(
         "fpl",
-        "element_gameweeks_predictions_2021_v01",
+        "element_gameweeks_predictions_2122_v01",
         predict_df,
         client,
         write_disposition="WRITE_TRUNCATE",

--- a/footbot/optimiser/sql/optimiser.sql
+++ b/footbot/optimiser/sql/optimiser.sql
@@ -9,7 +9,7 @@ WITH
       event,
       predicted_total_points
     FROM
-      `footbot-001.fpl.element_gameweeks_predictions_2021_v01` )
+      `footbot-001.fpl.element_gameweeks_predictions_2122_v01` )
   WHERE
     event BETWEEN {start_event}
     AND {end_event}
@@ -35,7 +35,7 @@ WITH
         100)/100 AS prob_playing,
       ROW_NUMBER() OVER(PARTITION BY element ORDER BY datetime DESC) AS is_current,
     FROM
-      `footbot-001.fpl.element_data_2021` )
+      `footbot-001.fpl.element_data_2122` )
   WHERE
     is_current = 1 )
   --------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/footbot/predictor/sql/predict.sql
+++ b/footbot/predictor/sql/predict.sql
@@ -1,6 +1,6 @@
 SELECT
   *
 FROM
-  `footbot-001.fpl.element_gameweeks_prediction_features_2021_v01`
+  `footbot-001.fpl.element_gameweeks_prediction_features_2122_v01`
 WHERE
   event > {current_event} -- future events


### PR DESCRIPTION
Set up cron jobs to write to new tables for upcoming 21/22 season.

Also fix bug with `make clean` commands. These were failing if no Docker entities existed. Followed this [suggestion](https://stackoverflow.com/a/38225298), which seems to work happily enough. It'll swallow any other error codes, but that seems better than `make clean` and all derivative commands failing.

This requires a google cloud changes once we're happy.

- [x] Unpause task queues
- [x] Deploy
- [x] Check `element_gameweeks_2122` and `element_future_fixtures_2122` populated correctly by task queues